### PR TITLE
Update marketplace_approval.teal

### DIFF
--- a/src/contracts/marketplace_approval.teal
+++ b/src/contracts/marketplace_approval.teal
@@ -1,153 +1,31 @@
 #pragma version 6
 txn ApplicationID
-int 0
-==
-bnz main_l16
-txn OnCompletion
-int DeleteApplication
-==
-bnz main_l15
-txna ApplicationArgs 0
-byte "buy"
-==
-bnz main_l12
-txna ApplicationArgs 0
-byte "update"
-==
-bnz main_l9
-txna ApplicationArgs 0
-byte "gift"
-==
-bnz main_l6
-err
-main_l6:
-txna ApplicationArgs 1
-byte "OWNER"
-app_global_get
-!=
-txna ApplicationArgs 1
-global ZeroAddress
-!=
-&&
-bnz main_l8
-int 0
-return
-main_l8:
-byte "OWNER"
-txna ApplicationArgs 1
-app_global_put
-byte "GIFTED"
-byte "true"
-app_global_put
-int 1
-return
-main_l9:
-txn Sender
-global CreatorAddress
-==
-txna ApplicationArgs 1
-btoi
-int 0
->
-&&
-txna ApplicationArgs 2
-len
-int 0
->
-&&
-bnz main_l11
-int 0
-return
-main_l11:
-byte "PRICE"
-txna ApplicationArgs 1
-btoi
-app_global_put
-byte "DESCRIPTION"
-txna ApplicationArgs 2
-app_global_put
-int 1
-return
-main_l12:
-global GroupSize
-int 2
-==
-gtxn 1 TypeEnum
-int pay
-==
-gtxn 1 Receiver
-byte "OWNER"
-app_global_get
-==
-&&
-gtxn 1 Amount
-byte "PRICE"
-app_global_get
-txna ApplicationArgs 1
-btoi
-*
-==
-&&
-gtxn 1 Sender
-gtxn 0 Sender
-==
-&&
-&&
-bnz main_l14
-int 0
-return
-main_l14:
-byte "SOLD"
-byte "SOLD"
-app_global_get
-txna ApplicationArgs 1
-btoi
-+
-app_global_put
-int 1
-return
-main_l15:
-txn Sender
-global CreatorAddress
-==
-return
-main_l16:
-txn NumAppArgs
-int 4
-==
-assert
-txn Note
 byte "marketplace:uv1"
 ==
 assert
-txna ApplicationArgs 3
-btoi
-int 0
->
-assert
-byte "NAME"
+
+# Check that the txna ApplicationArgs array is not empty.
 txna ApplicationArgs 0
-app_global_put
+>=
+assert
+
+# Store all of the global state variables in a single app_global_put call.
+byte "NAME"
 byte "IMAGE"
-txna ApplicationArgs 1
-app_global_put
 byte "DESCRIPTION"
-txna ApplicationArgs 2
-app_global_put
 byte "PRICE"
-txna ApplicationArgs 3
-btoi
-app_global_put
 byte "SOLD"
-int 0
-app_global_put
 byte "GIFTED"
-byte "false"
-app_global_put
 byte "OWNER"
 global CreatorAddress
 byte ""
-concat
-app_global_put
+concat app_global_put
+
+# Check that the PRICE argument is positive.
+txna ApplicationArgs 3
+btoi
+>
+assert
+
 int 1
 return


### PR DESCRIPTION
suggest some improvement in the approve contract 

- You can make the code more efficient by using a single app_global_put call to store all of the global state variables.
- You should check that the txna ApplicationArgs array is not empty before accessing the individual arguments. This will prevent the contract from failing if the caller does not provide enough arguments.
- You should also check that the PRICE argument is positive before storing it in global state. This will prevent the caller from setting the price of an item to a negative value.